### PR TITLE
Fix web auth not working; support underscores in bundle IDs

### DIFF
--- a/lib/src/auth0_utilities.dart
+++ b/lib/src/auth0_utilities.dart
@@ -1,5 +1,5 @@
 import 'dart:io' show Platform;
 
 String callbackUri({String bundleId, String domain}) {
-  return '${bundleId.toLowerCase()}://$domain/${Platform.isIOS ? 'ios' : 'android'}/$bundleId/callback';
+  return '${bundleId.toLowerCase().replaceAll('_', '')}://$domain/${Platform.isIOS ? 'ios' : 'android'}/$bundleId/callback';
 }

--- a/lib/src/web_auth.dart
+++ b/lib/src/web_auth.dart
@@ -56,8 +56,7 @@ class WebAuth {
         dynamic payload = {
           "code_challenge_method": codeChallengeMethod,
           "code_challenge": codeChallenge,
-          "clientId": this.clientId,
-          "redirectUri": redirectUri,
+          "redirect_uri": redirectUri,
           "scope": scope,
           "audience": audience,
           'state': expectedState,


### PR DESCRIPTION
1. Currently web-based authentication is not working with this module. Auth0 requires the parameters `redirect_uri` and `client_id`, however the class `WebAuth` uses the parameter names `redirectUri` and `clientId`.

* `client_id` is already present, hence `clientId` is suggested to simply be removed
* `redirectUri` is suggested to be renamed to `redirect_uri`

2. Furthermore this MR will support Flutter applications which use an underscore in their module name / bundle identifier. As the bundle identifier is used for the redirect scheme and URL schemes don't support underscores, underscores are removed from the bundle ID when generating the scheme name.