### PR TITLE
Issue #18 : Fix SIGABRT (NULLPOINTER) on iOS Web Login Flow

### DIFF
--- a/lib/src/web_auth.dart
+++ b/lib/src/web_auth.dart
@@ -53,25 +53,23 @@ class WebAuth {
           domain: this.domain,
         );
         String expectedState = state != null ? state : _state;
-        dynamic payload = {
-          "code_challenge_method": codeChallengeMethod,
-          "code_challenge": codeChallenge,
-          "clientId": this.clientId,
-          "redirectUri": redirectUri,
-          "scope": scope,
-          "audience": audience,
+        final Map<String, String> payload = {
+          'code_challenge_method': codeChallengeMethod,
+          'code_challenge': codeChallenge,
+          'client_id': this.clientId,
+          'redirect_uri': redirectUri,
+          'scope': scope,
+          'audience': audience,
           'state': expectedState,
           'client_id': this.clientId,
           'response_type': 'code',
         };
-        String authorizeUrl = Uri(
-          scheme: 'https',
-          host: this.domain,
-          path: 'authorize',
-          queryParameters: payload,
-        ).toString();
-        String accessToken = await _channel.invokeMethod(
-            'showUrl', {'url': authorizeUrl.replaceAll('+', ' ')});
+
+        final String authorizeUrl = Uri.https(this.domain, 'authorize', payload).toString();
+        final String auth0SafeUrl = authorizeUrl.replaceAll("+", "%20");
+
+        final String accessToken = await _channel.invokeMethod(
+            'showUrl', {'url': auth0SafeUrl});
         return exchange(
             code: accessToken, refirectUri: redirectUri, verifier: verifier);
       } on PlatformException catch (e) {


### PR DESCRIPTION
Corrects:
Using the Xcode debugger shows nil being passed to url SFSafariViewController *controller = [[SFSafariViewController alloc] initWithURL:url]; on FlutterAuth0Plugin.m:89. Prior warning is The specified URL has an unsupported scheme. Only HTTP and HTTPS URLs are supported. although the passed URL seems valid.

Corrects two issues in code, previous merged PR added spaces breaking URL
encoding. This caused the crash on iOS.

Additionally corrected incorrect query parameter names.
See: https://auth0.com/docs/api-auth/tutorials/authorization-code-grant-pkce