### PR TITLE
FIX #25 : Federated Logout Always Preformed

### DIFF
--- a/lib/src/webauth/index.dart
+++ b/lib/src/webauth/index.dart
@@ -84,9 +84,13 @@ class WebAuth {
   clearSession({bool federated = false}) async {
     var payload = Map.from({
       'clientId': this.clientId,
-      'returnTo': await callbackUri(this.domain),
-      'federated': federated.toString(),
+      'returnTo': await callbackUri(this.domain)
     });
+
+    if (federated) {
+      payload['federated'] = federated.toString();
+    }
+
     var logoutUrl = this.client.logoutUrl(payload);
     return auth0Channel.invokeMethod('authorize', logoutUrl);
   }


### PR DESCRIPTION
Regardless of the federated flag, it is always attempted. This fix removes any mention of the federated query parameter unless the federated flag is set to true.