### PR TITLE
Fix bug in auth/index.dart

### DIFF
--- a/lib/src/auth/index.dart
+++ b/lib/src/auth/index.dart
@@ -105,7 +105,7 @@ class Auth0Auth {
       http.Response res = await this.client.mutate('/oauth/token', payload);
       return await responseDataHandler(res);
     } catch (e) {
-      throw new Auth0Exeption(description: e);
+      throw new Auth0Exeption(description: e.toString());
     }
   }
 
@@ -160,7 +160,7 @@ class Auth0Auth {
       http.Response res = await this.client.mutate('/oauth/token', payload);
       return await responseDataHandler(res);
     } catch (e) {
-      throw new Auth0Exeption(description: e);
+      throw new Auth0Exeption(description: e.toString());
     }
   }
 
@@ -174,7 +174,7 @@ class Auth0Auth {
       http.Response res = await this.client.query('/userinfo');
       return await responseDataHandler(res);
     } catch (e) {
-      throw new Auth0Exeption(description: e);
+      throw new Auth0Exeption(description: e.toString());
     }
   }
 


### PR DESCRIPTION
## Description
Fix exception description by casting it to string. If not doing casting, it will throw another type error when it throw the exception, which makes the exception description message confusing.
