### PR TITLE
Make package available to ios

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,3 +23,5 @@ flutter:
       android:
         package: io.flutter.plugins.flutterauth0
         pluginClass: FlutterAuth0Plugin
+      ios:
+        pluginClass: FlutterAuth0Plugin


### PR DESCRIPTION
Hi - I was having problems getting the example to run on iOS, and it turned out these missing lines from the `pubspec.yaml` were required. Not sure if this is necessary for the package in normal usage via `flutter pub get` - but they enable the example to work, at least.